### PR TITLE
Customize runme.sh behavior

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
+# =============================================================================
+# Project: easy-jenkins
+#
+# Description: Top-level script to start the Docker containers
+#
+# Usage examples:
+#
+# 1. Create Docker machine with default configuration
+#     $ ./runme.sh
+#
+# 2. Customize Docker machine VM configuration
+#     $ VM=test-vm VM_NUM_CPUS=3 VM_MEM_SIZEMB=1024 VM_DISK_SIZEMB=10000 \
+#       ./runme.sh
+# =============================================================================
 
 [[ "${VM}" = "" ]] && VM=easy-jenkins
+[[ "${VM_NUM_CPUS}" = "" ]] && VM_NUM_CPUS=2
+[[ "${VM_MEM_SIZEMB}" = "" ]] && VM_MEM_SIZEMB=3048
+[[ "${VM_DISK_SIZEMB}" = "" ]] && VM_DISK_SIZEMB=50000
 
 set -e
 
@@ -9,10 +26,11 @@ set -e
 if docker-machine ls | grep ${VM} >/dev/null; then
     echo "WARNING: Docker machine ${VM} exists, skipping docker-machine create"
 else
+    echo "INFO: Creating VirtualBox VM ${VM} (cpu:${VM_NUM_CPUS}, memory:${VM_MEM_SIZEMB} MB, disk:${VM_DISK_SIZEMB} MB)"
     docker-machine create --driver virtualbox \
-      --virtualbox-cpu-count "2" \
-      --virtualbox-disk-size "50000" \
-      --virtualbox-memory "3048" \
+      --virtualbox-cpu-count "${VM_NUM_CPUS}" \
+      --virtualbox-memory "${VM_MEM_SIZEMB}" \
+      --virtualbox-disk-size "${VM_DISK_SIZEMB}" \
       ${VM}
 fi
 if docker-machine status ${VM} | grep -v Running >/dev/null; then


### PR DESCRIPTION
through the following environment variables:

- VM: Virtual Machine name (default: easy-jenkins)
- VM_NUM_CPUS: Number of CPUs allocated to the VM (default: 2)
- VM_MEM_SIZEMB: Memory allocated to the VM in MB (default: 3048)
- VM_DISK_SIZEMB: Disk allocated to the VM in MB (default: 50000)

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>