### PR TITLE
myjenkins: Use Docker daemon from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "51000:50000"
     tty: true
     privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   # build-yocto-slave:
   #   image: gmacario/build-yocto:latest

--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -1,13 +1,18 @@
+# ===========================================================================================
 # Project: gmacario/easy-jenkins
 #
-# Extend the standard Jenkins LTS Docker image with:
-# - Jenkins workflow plugins
-# - Docker
+# File: myjenkins/Dockerfile
+#
+# Purpose: Extend the standard Jenkins LTS Docker image with:
+#   - docker
+#   - docker-compose
+#   - gosu
+#   - Additional Jenkins plugins (specified in plugins.txt)
 #
 # Credits to https://github.com/camiloribeiro/cdeasy
-# - https://github.com/camiloribeiro/cdeasy/blob/master/docker/jenkins/Dockerfile
-
+# ===========================================================================================
 FROM jenkins:latest
+
 MAINTAINER Gianpaolo Macario <gmacario@gmail.com>
 
 USER root
@@ -15,11 +20,11 @@ RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
     curl \
-    wget \
-    lxc \
-    iptables \
     dos2unix \
-    groovy2
+    groovy2 \
+    iptables \
+    lxc \
+    wget
 
 # Install gosu
 RUN curl -o /usr/local/bin/gosu -fsSL \
@@ -27,8 +32,12 @@ RUN curl -o /usr/local/bin/gosu -fsSL \
     chmod +x /usr/local/bin/gosu
 
 # Install Docker
-RUN wget -qO- https://get.docker.com/ | sh
+RUN curl -fsSL https://get.docker.com/ | sh
 RUN usermod -aG docker jenkins
+
+# Workaround until user-namespaces are working
+# Add user "jenkins" to group "docker" of host (works with boot2docker)
+RUN usermod -aG 100 jenkins
 
 # Install docker-compose
 RUN curl -o /usr/local/bin/docker-compose -fsSL \

--- a/myjenkins/start.sh
+++ b/myjenkins/start.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 sleep 5
-service docker start
+
+# To use host Docker daemon, comment out line `service docker start`
+# and run container with `--volume=/var/run/docker.sock:/var/run/docker.sock`
+# service docker start
+
 gosu jenkins /usr/local/bin/jenkins.sh
 
 # EOF


### PR DESCRIPTION
Instead than running a separate Docker daemon,
run service myjenkins bind mounting host .

See https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/

Fix https://github.com/gmacario/easy-jenkins/issues/31

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>