### PR TITLE
building-wtfapp-udooneo: Change used Docker image

### DIFF
--- a/docs/building-wtfapp-udooneo.md
+++ b/docs/building-wtfapp-udooneo.md
@@ -67,8 +67,4 @@ You may watch the build logs at `${JENKINS_URL}/job/build_wtfapp_udooneo/lastBui
 
 <!-- (2016-02-29 15:25 CET) http://mv-linux-powerhorse.solarma.it:9080/job/build_wtfapp_udooneo/lastBuild/consoleText -->
 
-```
-TODO
-```
-
 <!-- EOF -->

--- a/docs/building-wtfapp-udooneo.md
+++ b/docs/building-wtfapp-udooneo.md
@@ -37,7 +37,7 @@ Inside the project configuration page, fill-in the following information:
   - Build Environment
     - Build inside a Docker container: Yes
       - Docker image to use: Pull docker image from repository
-        - Image id/tag: `gmacario/wtfapp-devenv`
+        - Image id/tag: `gmacario/android-devenv`
   - Build
     - Execute shell
       - Command


### PR DESCRIPTION
Perform the following steps before merging:
- [x] Change text in doc
- [x] Setup automated build https://hub.docker.com/r/gmacario/android-devenv/
- [x] Execute successful build of Docker image gmacario/android-devenv
- [x] Reproduce build instructions [building-wtfapp-udooneo.md](https://github.com/gmacario/easy-jenkins/blob/master/docs/building-wtfapp-udooneo.md)
- [ ] Remove https://hub.docker.com/r/gmacario/wtfapp-devenv/

See https://github.com/gmacario/wtf-docs/pull/24

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
