### PR TITLE
myjenkins: Use Docker engine from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,10 @@ services:
     ports:
       - "9080:8080"
       - "51000:50000"
-    tty: true
-    privileged: true
+    # tty: true
+    # privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   # build-yocto-slave:
   #   image: gmacario/build-yocto:latest

--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -73,14 +73,15 @@ RUN install-plugins.sh \
     windows-slaves:1.2 \
     workflow-aggregator:2.5
 
-COPY start.sh /tmp/start.sh
-RUN chmod +x /tmp/start.sh && dos2unix /tmp/start.sh
-
 COPY seed.groovy /usr/share/jenkins/ref/init.groovy.d/seed.groovy
 
 RUN touch /var/run/docker.sock
 
-USER root
-ENTRYPOINT ["/bin/bash", "-c", "/tmp/start.sh"]
+# COPY start.sh /tmp/start.sh
+# RUN chmod +x /tmp/start.sh && dos2unix /tmp/start.sh
+# USER root
+# ENTRYPOINT ["/bin/bash", "-c", "/tmp/start.sh"]
+
+USER ${user}
 
 # EOF

--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -81,11 +81,6 @@ COPY seed.groovy /usr/share/jenkins/ref/init.groovy.d/seed.groovy
 
 RUN touch /var/run/docker.sock
 
-# COPY start.sh /tmp/start.sh
-# RUN chmod +x /tmp/start.sh && dos2unix /tmp/start.sh
-# USER root
-# ENTRYPOINT ["/bin/bash", "-c", "/tmp/start.sh"]
-
 USER ${user}
 
 # EOF

--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -30,6 +30,10 @@ RUN curl -o /usr/local/bin/gosu -fsSL \
 RUN wget -qO- https://get.docker.com/ | sh
 RUN usermod -aG docker jenkins
 
+# Add user "jenkins" to group "docker" of the Docker host
+# (on boot2docker, group "docker" has gid=100)
+RUN usermod -aG 100 jenkins
+
 # Install docker-compose
 RUN curl -o /usr/local/bin/docker-compose -fsSL \
     "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-$(uname -s)-$(uname -m)" && \

--- a/myjenkins/start.sh
+++ b/myjenkins/start.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-sleep 5
-service docker start
-gosu jenkins /usr/local/bin/jenkins.sh
-
-# EOF


### PR DESCRIPTION
Replace Docker-in-Docker with bind mount of `/var/run/docker.sock` from host.

Tested on Docker host running on

* [x] Ubuntu 16.04.2 64-bit LTS (mv-linux-powerhorse)
* [x] Ubuntu 16.04.2 64-bit LTS (ies-genbld01-ub16)
* [ ] Boot2Docker 1.13 (Docker Toolbox on MS Windows 10)
* [ ] Boot2Docker 1.13 (Docker Toolbox on OS X)

Should (eventually!) fix https://github.com/gmacario/easy-jenkins/issues/31

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>