### PR TITLE
runme.sh: Print initial Jenkins admin password (v2)

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -171,13 +171,11 @@ if ${USE_DOCKER_MACHINE}; then
     echo "INFO: Browse http://$(docker-machine ip ${VM}):9080/ to access the Jenkins dashboard"
 fi    # if ${USE_DOCKER_MACHINE} ...
 
-INITIAL_PASS=$(docker-compose exec myjenkins sh -c \
+INITIAL_PASS=$(docker-compose exec -T myjenkins sh -c \
     "[ -e /var/jenkins_home/secrets/initialAdminPassword ] && cat /var/jenkins_home/secrets/initialAdminPassword")
 
-# INITIAL_PASS=$(docker-compose exec myjenkins cat /var/jenkins_home/secrets/initialAdminPassword)
-
 if [ "${INITIAL_PASS}" != "" ]; then
-    echo "INFO: The initial administrator password is set to ${INITIAL_PASS}"
+    echo "INFO: Initial administrator password: ${INITIAL_PASS}"
 fi
 
 # EOF

--- a/runme.sh
+++ b/runme.sh
@@ -165,6 +165,9 @@ fi    # if ${USE_DOCKER_MACHINE} ...
 
 docker-compose up -d
 
+# Wait a reasonable time to make sure initialAdminPassword is generated
+sleep 30
+
 if ${USE_DOCKER_MACHINE}; then
     echo "INFO: Run the following command to configure your shell:"
     echo "INFO: eval \$(docker-machine env ${VM})"

--- a/runme.sh
+++ b/runme.sh
@@ -172,6 +172,8 @@ if ${USE_DOCKER_MACHINE}; then
 fi    # if ${USE_DOCKER_MACHINE} ...
 
 INITIAL_PASS=$(docker-compose exec myjenkins cat /var/jenkins_home/secrets/initialAdminPassword)
-echo "INFO: The initial administrator password is set to ${INITIAL_PASS}"
+if [ "${INITIAL_PASS}" != "" ]; then
+    echo "INFO: The initial administrator password is set to ${INITIAL_PASS}"
+fi
 
 # EOF

--- a/runme.sh
+++ b/runme.sh
@@ -166,9 +166,12 @@ fi    # if ${USE_DOCKER_MACHINE} ...
 docker-compose up -d
 
 if ${USE_DOCKER_MACHINE}; then
-    echo "INFO: Browse http://$(docker-machine ip ${VM}):9080/ to access the Jenkins dashboard"
     echo "INFO: Run the following command to configure your shell:"
     echo "INFO: eval \$(docker-machine env ${VM})"
+    echo "INFO: Browse http://$(docker-machine ip ${VM}):9080/ to access the Jenkins dashboard"
 fi    # if ${USE_DOCKER_MACHINE} ...
+
+INITIAL_PASS=$(docker-compose exec myjenkins cat /var/jenkins_home/secrets/initialAdminPassword)
+echo "INFO: The initial administrator password is set to ${INITIAL_PASS}"
 
 # EOF

--- a/runme.sh
+++ b/runme.sh
@@ -171,7 +171,11 @@ if ${USE_DOCKER_MACHINE}; then
     echo "INFO: Browse http://$(docker-machine ip ${VM}):9080/ to access the Jenkins dashboard"
 fi    # if ${USE_DOCKER_MACHINE} ...
 
-INITIAL_PASS=$(docker-compose exec myjenkins cat /var/jenkins_home/secrets/initialAdminPassword)
+INITIAL_PASS=$(docker-compose exec myjenkins sh -c \
+    "[ -e /var/jenkins_home/secrets/initialAdminPassword ] && cat /var/jenkins_home/secrets/initialAdminPassword")
+
+# INITIAL_PASS=$(docker-compose exec myjenkins cat /var/jenkins_home/secrets/initialAdminPassword)
+
 if [ "${INITIAL_PASS}" != "" ]; then
     echo "INFO: The initial administrator password is set to ${INITIAL_PASS}"
 fi


### PR DESCRIPTION
Tested on:

- [x] Docker 1.13.1, Ubuntu 16.04.2 LTS 64-bit (mv-linux-powerhorse)
- [x] Docker 1.13.1, Boot2Docker 1.13 in a VirtualBox VM (Docker Toolbox on Windows 10 - itm-gpaolo-w10)
- [x] Docker 1.13.1, Boot2Docker 1.13 in a VirtualBox VM (Docker Toolbox on macOS Sierra v10.12.3 (mac-tizy)
- [x] Docker 1.13.1-beta42 (15350) for Mac (macOS Sierra v10.12.3 - mac-tizy)

Fix https://github.com/gmacario/easy-jenkins/issues/111

Signed-off-by: Gianpaolo Macario gianpaolo_macario@mentor.com