### PR TITLE
myjenkins/Dockerfile: Reset to user "jenkins"

### DIFF
--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -81,6 +81,6 @@ COPY seed.groovy /usr/share/jenkins/ref/init.groovy.d/seed.groovy
 
 RUN touch /var/run/docker.sock
 
-USER ${user}
+USER jenkins
 
 # EOF


### PR DESCRIPTION
The Dockerfile defaulted to user `${user}` which was not defined.

See https://github.com/jenkinsci/docker#installing-more-tools

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>