### PR TITLE
myjenkins: Update plugins with security issues

### DIFF
--- a/myjenkins/Dockerfile
+++ b/myjenkins/Dockerfile
@@ -43,11 +43,11 @@ RUN mkdir -p /usr/share/jenkins/ref/plugins/tmp
 
 # Install additional Jenkins plugins
 RUN install-plugins.sh \
-    ant:1.5 \
+    ant:1.6 \
     antisamy-markup-formatter:1.5 \
-    blueocean:1.1.5 \
+    blueocean:1.1.6 \
     blueocean-pipeline-editor:0.2.0 \
-    delivery-pipeline-plugin:1.0.3 \
+    delivery-pipeline-plugin:1.0.4 \
     docker-build-publish:1.3.2 \
     docker-custom-build-environment:1.6.5 \
     docker-plugin:0.16.2 \


### PR DESCRIPTION
On 2017-08-07 updates to Jenkins plugins have been released to fix several security vulnerabilities.

See https://jenkins.io/blog/2017/08/07/security-advisory/

Update to all available plugins as of 2017-08-11:

* ant:1.6
* blueocean:1.1.6
* delivery-pipeline-plugin:1.0.4

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>