### PR TITLE
run.sh: Create secrets/adminpw if file is missing

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -176,6 +176,14 @@ echo "DEBUG: CASC_JENKINS_CONFIG=${CASC_JENKINS_CONFIG}"
 # echo "DEBUG: Inspecting environment variables"
 # printenv | sort
 
+if [ ! -e "secrets/adminpw" ]; then
+    echo "WARNING: Cannot find file secrets/adminpw - Creating it"
+    INITIAL_PASS="Ver!s4cr4tpa55wd"
+    mkdir -p secrets
+    echo "${INITIAL_PASS}" > secrets/adminpw
+    echo "INFO: Initial administrator password: ${INITIAL_PASS}"
+fi
+
 docker-compose up -d
 
 # Wait a reasonable time to make sure initialAdminPassword is generated

--- a/runme.sh
+++ b/runme.sh
@@ -181,7 +181,7 @@ if [ ! -e "secrets/adminpw" ]; then
     INITIAL_PASS="Ver!s4cr4tpa55wd"
     mkdir -p secrets
     echo "${INITIAL_PASS}" > secrets/adminpw
-    echo "INFO: Initial administrator password: ${INITIAL_PASS}"
+    echo "INFO: Initial Jenkins admin password: ${INITIAL_PASS}"
 fi
 
 docker-compose up -d
@@ -199,7 +199,7 @@ INITIAL_PASS=$(docker-compose exec -T myjenkins sh -c \
     "[ -e /var/jenkins_home/secrets/initialAdminPassword ] && cat /var/jenkins_home/secrets/initialAdminPassword")
 
 if [ "${INITIAL_PASS}" != "" ]; then
-    echo "INFO: Initial administrator password: ${INITIAL_PASS}"
+    echo "INFO: Initial Jenkins admin password: ${INITIAL_PASS}"
 fi
 
 # EOF


### PR DESCRIPTION
Prevents runtime errors if the user forgot to supply the Docker secrets file
containing the Jenkins administration password

Signed-off-by: Gianpaolo Macario <gianpaolo.macario@solarma.it>