### PR TITLE
casc_configs/gmpowerhorse.yaml: Remove <plugins> root element

### DIFF
--- a/casc_configs/gmpowerhorse.yaml
+++ b/casc_configs/gmpowerhorse.yaml
@@ -1,9 +1,5 @@
 # File: casc_plugins/gmpowerhorse.yaml
 
-plugins:
-  sites:
-  - id: "default"
-    url: "https://updates.jenkins.io/update-center.json"
 jenkins:
   agentProtocols:
   - "JNLP4-connect"


### PR DESCRIPTION
The configuration-as-code-plugin removed support for the  root element since v1.8.
See <https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.8>

Fix #298

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>