### PR TITLE
docker-compose.yml: Expose JNLP port as 50000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # - CASC_JENKINS_CONFIG:/var/jenkins_home/casc_configs
     ports:
       - "9080:8080"
-      - "51000:50000"
+      - "50000:50000"
     # tty: true
     # privileged: true
     network_mode: "bridge"


### PR DESCRIPTION
This enables attaching build executors on Windows nodes via JNLP

See https://github.com/jenkinsci/docker#toc4

Signed-off-by: Gianpaolo Macario <gianpaolo.macario@solarma.it>